### PR TITLE
update story plop template to include component import

### DIFF
--- a/plop-templates/component.stories.ts.hbs
+++ b/plop-templates/component.stories.ts.hbs
@@ -1,5 +1,6 @@
-import { StoryObj } from '@storybook/web-components';
+import { StoryObj } from '@storybook/web-components-vite';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
+import './index.js';
 import type { {{pascalCase tagName}} } from './index.js';
 
 const { args, argTypes, events, template } = getStorybookHelpers('{{kebabCase tagName}}');


### PR DESCRIPTION
Addresses two minor issues in `plop-templates/component.stories.ts.hbs`:

1. The `StoryObj` should be from `@storybook/web-components-vite`. The example button story provided in the starter has this right, looks like just the template got missed.
2. The side-effect import was missing.

I wasn't sure if the second was intentional (e.g. if storybook helpers were supposed to be handling the import), so I went and looked at the [demo stories in the storybook-helpers repo](https://github.com/wc-toolkit/storybook-helpers/blob/main/demo/src/my-element/my-element.stories.ts), and they do have the side-effect import.