### PR TITLE
Normalize component names & update stories

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -9,6 +9,9 @@ import { lazyLoaderPlugin } from '@wc-toolkit/lazy-loader';
 import { cemDeprecatorPlugin } from 'custom-elements-manifest-deprecator';
 import { cemSorterPlugin } from '@wc-toolkit/cem-sorter';
 
+// Strip out custom prefixes.
+const distComponentName = (tagName) => tagName.replace(/^[^-]+-/, '');
+
 export default {
   /** Globs to analyze */
   globs: ['src/components/**/*.ts'],
@@ -25,30 +28,30 @@ export default {
     reactWrapperPlugin({
       outdir: 'react',
       modulePath: (_, tagName) =>
-        `../dist/components/${tagName.replace('my-', '')}/index.js`,
+        `../dist/components/${distComponentName(tagName)}/index.js`,
     }),
     jsxTypesPlugin({
       outdir: 'types',
       stronglyTypedEvents: true,
       modulePath: (_, tagName) =>
-        `../dist/components/${tagName.replace('my-', '')}/${tagName.replace('my-', '')}.js`,
+        `../dist/components/${distComponentName(tagName)}/${distComponentName(tagName)}.js`,
     }),
     customElementVuejsPlugin({
       outdir: 'types',
       fileName: 'custom-element-vuejs.d.ts',
       modulePath: (_, tagName) =>
-        `../dist/components/${tagName.replace('my-', '')}/${tagName.replace('my-', '')}.js`,
+        `../dist/components/${distComponentName(tagName)}/${distComponentName(tagName)}.js`,
     }),
     customElementSveltePlugin({
       outdir: 'types',
       fileName: 'custom-element-svelte.d.ts',
       modulePath: (_, tagName) =>
-        `../dist/components/${tagName.replace('my-', '')}/${tagName.replace('my-', '')}.js`,
+        `../dist/components/${distComponentName(tagName)}/${distComponentName(tagName)}.js`,
     }),
     lazyLoaderPlugin({
       outdir: 'cdn',
       importPathTemplate: (_, tagName) =>
-        `../dist/components/${tagName.replace('my-', '')}/${tagName.replace('my-', '')}.js`,
+        `../dist/components/${distComponentName(tagName)}/${distComponentName(tagName)}.js`,
     }),
 
     jsDocTagsPlugin({

--- a/plop-templates/component.stories.ts.hbs
+++ b/plop-templates/component.stories.ts.hbs
@@ -6,7 +6,7 @@ import type { {{pascalCase tagName}} } from './index.js';
 const { args, argTypes, events, template } = getStorybookHelpers('{{kebabCase tagName}}');
 
 export default {
-  title: 'Components/{{pascalCase name}}',
+  title: 'Components/{{dashToTitle name}}',
   component: '{{kebabCase tagName}}',
   args,
   argTypes,

--- a/plopfile.js
+++ b/plopfile.js
@@ -24,10 +24,17 @@ export default function (plop) {
       },
     ],
     actions: function (data) {
-      const basename = data?.name;
+      // Normalize input to kebab-case so camelCase or PascalCase becomes valid kebab-case
+      const originalName = data?.name || '';
+      const basename = plop.getHelper('kebabCase')(originalName);
+
+      // Use the sanitized name everywhere the templates expect `name`
+      data.name = basename;
+
+      // Validate the sanitized kebab-case name
       if (
-        // Must only contain alphanumeric characters and dashes
-        !/[a-z0-9-]+/.test(basename) ||
+        // Must only contain lowercase alphanumeric characters and dashes
+        !/^[a-z0-9-]+$/.test(basename) ||
         // Must start with a letter
         !/^[a-z]/.test(basename) ||
         // Must not end in a dash
@@ -41,6 +48,7 @@ export default function (plop) {
 
       const BASE_PATH = `src/components/{{kebabCase name}}`;
 
+      // Ensure tagName uses the sanitized kebab-case name
       data.tagName = data?.prefix ? `${data.prefix}-${data.name}` : data.name;
 
       return [

--- a/src/components/button/button.stories.ts
+++ b/src/components/button/button.stories.ts
@@ -29,5 +29,6 @@ export const Default: Story = {
   render: args => html`${template(args)}`,
   args: {
     'default-slot': 'My Button',
+    'control-part': '',
   },
 };


### PR DESCRIPTION
- Sanitize and validate component names in plopfile: input is normalized to kebab-case, validated with a stricter /^[a-z0-9-]+$/ pattern, and data.tagName is derived from the sanitized name (with prefix if present). For example, when using `npm run new`, buttonGroup would be normalized to button-group.

- Update story template title to use `dashToTitle` for nicer Storybook titles, and to prevent a bug where created files would not be nested in the component's folder.

- Add missing 'control-part' default arg to `src/components/button/button.stories.ts.`